### PR TITLE
update golangci-lint from 1.46 to 1.50

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46
+          version: v1.50
   sec:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
lint job failed.
https://github.com/oke-py/contributions/actions/runs/3775054692/jobs/6417496975